### PR TITLE
Fix: error handling

### DIFF
--- a/lib/poloniex.js
+++ b/lib/poloniex.js
@@ -59,6 +59,9 @@ module.exports = (function() {
             debug(`${options.url}, ${options.method}, ${JSON.stringify(options.method === 'GET' && options.qs || options.form)}`);
             request(options, function(error, response, body) {
                 let err = error;
+                if (!err && typeof response.body === 'undefined'){
+                    err = new Error('Poloniex error: Undefined response');
+                }
                 if (!err && response.statusCode !== 200) {
                     err =  new Error(`Poloniex error ${response.statusCode}: ${response.body.error || response.body}`);
                 }


### PR DESCRIPTION
Fixed error:
```
                    err =  new Error(`Poloniex error ${response.statusCode}: ${response.body.error || response.body}`);
                                                                                            ^
TypeError: Cannot read property 'error' of undefined
```