### PR TITLE
Working through proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ poloniex = new Poloniex('myKey', 'mySecret', { socketTimeout: 130000 });
 
 * `socketTimeout` - the number of milliseconds to wait for the server to send the response before aborting the request 
 * `keepAlive` - keep open and reuse the underlying TCP connection
+* `proxy` - proxy to be used for requests
  
 
 ## REST API

--- a/lib/poloniex.js
+++ b/lib/poloniex.js
@@ -102,6 +102,7 @@ class Poloniex extends EventEmitter {
     options.headers['User-Agent'] = options.headers['User-Agent'] || USER_AGENT;
     options.strictSSL = STRICT_SSL;
     options.timeout = this.options && this.options.socketTimeout || DEFAULT_SOCKETTIMEOUT;
+    options.proxy = this.options && this.options.hasOwnProperty('proxy') ? this.options.proxy : null;
     options.forever = this.options && this.options.hasOwnProperty('keepAlive') ? this.options.keepAlive : DEFAULT_KEEPALIVE;
     if (options.forever) {
       options.headers['Connection'] = options.headers['Connection'] || 'keep-alive';
@@ -142,6 +143,7 @@ class Poloniex extends EventEmitter {
     options.headers['User-Agent'] =  options.headers['User-Agent'] || USER_AGENT;
     options.strictSSL = Poloniex.STRICT_SSL;
     options.timeout = this.options && this.options.socketTimeout || DEFAULT_SOCKETTIMEOUT;
+    options.proxy = this.options && this.options.hasOwnProperty('proxy') ? this.options.proxy : null;
     options.forever = this.options && this.options.hasOwnProperty('keepAlive') ? this.options.keepAlive : DEFAULT_KEEPALIVE;
     if (options.forever) {
       options.headers['Connection'] = options.headers['Connection'] || 'keep-alive';


### PR DESCRIPTION
Very simple change to allow passing `proxy` option to underlying request calls. Using proxy can help bypass captchas in API for some countries.