### PR TITLE
fix: TypeError: Cannot read property 'currencyPair' of undefined

### DIFF
--- a/lib/poloniex.js
+++ b/lib/poloniex.js
@@ -602,7 +602,7 @@ class Poloniex extends EventEmitter {
               }
 
               let data = {
-                currencyPair: markets.byID[rawData[0]].currencyPair,
+                currencyPair: ((typeof markets.byID[rawData[0]] !== 'undefined') ? markets.byID[rawData[0]].currencyPair : null),
                 last: rawData[1],
                 lowestAsk: rawData[2],
                 highestBid: rawData[3],


### PR DESCRIPTION
a quickfix for:

```js
poloniex-api-node/lib/poloniex.js:603
                currencyPair: markets.byID[rawData[0]].currencyPair,
                                                      ^
TypeError: Cannot read property 'currencyPair' of undefined
```

this happens when a currencypair does not occur in poloniex-api-node/lib/markets.js