### PR TITLE
Ignore unknown market

### DIFF
--- a/lib/poloniex.js
+++ b/lib/poloniex.js
@@ -597,7 +597,7 @@ class Poloniex extends EventEmitter {
             case ws2SubscriptionToChannelIdMap.ticker: {
               let channelName = 'ticker';
               let rawData = msg[2];
-              if (!rawData) {
+              if (!rawData || !markets.byID[rawData[0]]) {
                 return;
               }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "poloniex-api-node",
-  "version": "1.6.0",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -990,14 +990,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1006,6 +998,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "poloniex-api-node",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Simple node.js wrapper for Poloniex REST and WebSocket (push) API. Supports Callback and Promise",
   "main": "./lib/poloniex.js",
   "scripts": {


### PR DESCRIPTION
The application crashes if it receives a message with an unknown market id (for example with id 200):
```
TypeError: Cannot read property 'currencyPair' of undefined
    at WebSocket.ws.onmessage (/Users/denisbezrukov/projects/web/poloniex-trader/node_modules/poloniex-api-node/lib/poloniex.js:605:56)
    at WebSocket.onMessage (/Users/denisbezrukov/projects/web/poloniex-trader/node_modules/ws/lib/EventTarget.js:99:16)
    at emitOne (events.js:116:13)
```

I think we could just ignore these messages.