### PR TITLE
Added agent option

### DIFF
--- a/lib/poloniex.js
+++ b/lib/poloniex.js
@@ -571,7 +571,7 @@ class Poloniex extends EventEmitter {
             });
             const markets = {byID};
 
-            if (this.options.agent) {
+            if (this.options && this.options.agent) {
               options.agent = this.options.agent
             }
 

--- a/lib/poloniex.js
+++ b/lib/poloniex.js
@@ -102,6 +102,7 @@ class Poloniex extends EventEmitter {
     options.strictSSL = STRICT_SSL;
     options.timeout = this.options && this.options.socketTimeout || DEFAULT_SOCKETTIMEOUT;
     options.proxy = this.options && this.options.hasOwnProperty('proxy') ? this.options.proxy : null;
+    options.agent = this.options && this.options.hasOwnProperty('agent') ? this.options.agent : null;
     options.forever = this.options && this.options.hasOwnProperty('keepAlive') ? this.options.keepAlive : DEFAULT_KEEPALIVE;
     if (options.forever) {
       options.headers['Connection'] = options.headers['Connection'] || 'keep-alive';
@@ -143,6 +144,7 @@ class Poloniex extends EventEmitter {
     options.strictSSL = Poloniex.STRICT_SSL;
     options.timeout = this.options && this.options.socketTimeout || DEFAULT_SOCKETTIMEOUT;
     options.proxy = this.options && this.options.hasOwnProperty('proxy') ? this.options.proxy : null;
+    options.agent = this.options && this.options.hasOwnProperty('agent') ? this.options.agent : null;
     options.forever = this.options && this.options.hasOwnProperty('keepAlive') ? this.options.keepAlive : DEFAULT_KEEPALIVE;
     if (options.forever) {
       options.headers['Connection'] = options.headers['Connection'] || 'keep-alive';
@@ -568,7 +570,12 @@ class Poloniex extends EventEmitter {
               }
             });
             const markets = {byID};
-            this.ws = new WebSocket(WS2_URI, [], options);
+
+            if (this.options.agent) {
+              options.agent = this.options.agent
+            }
+
+            this.ws = new WebSocket(WS2_URI, options);
 
             this.ws.onopen = (e) => {
               this.ws.keepAliveId = setInterval(() => {


### PR DESCRIPTION
This option can passed to Poloniex constructor to set specific http.Agent
for all API calls and WebSocket connection. It is useful for using proxy
to avoid the 403 error with CAPTCHA (see #20).